### PR TITLE
Modification for [IOS-1005] allow queries to complete on a background thread.

### DIFF
--- a/Mars/Mars/MDatabase.h
+++ b/Mars/Mars/MDatabase.h
@@ -22,8 +22,12 @@
 - (id)initWithPath:(NSString *)path schema:(NSString *)schema;
 - (id)initWithDBFileName:(NSString *)dbFileName schemaFileName:(NSString *)schemaFileName;
 
-// Non blocking version
+// Non blocking versions
 - (NSOperation *)query:(MQuery *)query completionBlock:(void (^)(NSError *err, id result))completionBlock;
+
+- (NSOperation *)query:(MQuery *)query
+withCompletionOnMainThread:(BOOL)completionOnMainThread
+       completionBlock:(void (^)(NSError *err, id result))completionBlock;
 
 // Blocking version
 - (id)query:(MQuery *)query error:(NSError **)err;


### PR DESCRIPTION
I'd like to modify the `MDatabase.h` interface as part of JIRA issue [[IOS-1005]](https://virtru.atlassian.net/browse/IOS-1005). 

By default, a query would still have its completion block execute on the main thread. However, I've added a new `query:withCompletionOnMainThread:completionBlock:` method that would allow you to override the default behavior so a query _could_ also execute its completion block on the current thread instead.