### PR TITLE
[IOS-1769] - iOS Mail crash in Database code -[MDatabase (AsyncAdditiqueries:completionBlock:]_block_invoke + 112

### DIFF
--- a/Mars/Mars/MDatabase+AsyncAdditions.m
+++ b/Mars/Mars/MDatabase+AsyncAdditions.m
@@ -28,6 +28,14 @@
                 completionBlock(err, nil);
                 return;
             }
+            
+            if (!result) {
+                NSError *error = [NSError errorWithDomain:@"MDatabase"
+                                                     code:-1
+                                                 userInfo:@{NSLocalizedDescriptionKey: @"query result is nil"}];
+                completionBlock(error, nil);
+                return;
+            }
 
             NSUInteger pos = [queries indexOfObject:query];
             results[pos] = result;


### PR DESCRIPTION
Bug: see this crash many times in the Xcode organizer for the release v3.2.1

Fix: Make sure the query result is not nil before adding to the array.